### PR TITLE
Install necessary CI system dependencies

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,6 +16,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: System Dependencies
+      run: sudo apt-get install libasound2-dev libjack-dev libjack0 fontconfig
     - name: Build
       run: cargo build --verbose
     - name: Run tests


### PR DESCRIPTION
* In the future, we might want to reduce the system dependencies that are necessary to run the unit tests.