### PR TITLE
Fix note registry bug: incorrect note sorting

### DIFF
--- a/src/note.rs
+++ b/src/note.rs
@@ -1,6 +1,5 @@
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
-use std::cmp::Ordering;
 use std::error::Error;
 use std::fmt;
 
@@ -82,25 +81,6 @@ impl PartialEq for Note {
 
 impl Eq for Note {}
 
-impl PartialOrd for Note {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for Note {
-    fn cmp(&self, other: &Self) -> Ordering {
-        if self.octave == other.octave {
-            return self.name.cmp(&other.name);
-        }
-        self.octave.cmp(&other.octave)
-    }
-}
-
-pub struct NoteRegistry {
-    notes: Vec<Note>,
-}
-
 #[derive(Debug)]
 struct DuplicateNoteError(String);
 impl fmt::Display for DuplicateNoteError {
@@ -119,17 +99,30 @@ impl fmt::Display for InvalidTuningError {
 }
 impl Error for InvalidTuningError {}
 
+pub struct NoteRegistry {
+    notes: Vec<Note>,
+}
+
 impl NoteRegistry {
     pub fn from_csv(csv_path: &str) -> Result<NoteRegistry, Box<dyn Error>> {
-        let mut notes = parse_csv(csv_path)?;
-        notes.sort_unstable();
-        for i in 0..notes.len() - 1 {
-            if notes[i] == notes[i + 1] {
-                return Err(Box::new(DuplicateNoteError(format!(
-                    "Guitar frequency list has duplicates: {:?} and {:?}",
-                    notes[i],
-                    notes[i + 1]
-                ))));
+        let notes = parse_csv(csv_path)?;
+        match NoteRegistry::from_notes(notes) {
+            Ok(v) => Ok(v),
+            Err(e) => Err(Box::new(e)),
+        }
+    }
+
+    fn from_notes(mut notes: Vec<Note>) -> Result<NoteRegistry, DuplicateNoteError> {
+        notes.sort_unstable_by(|a, b| a.frequency.partial_cmp(&b.frequency).unwrap());
+        if !notes.is_empty() {
+            for i in 0..notes.len() - 1 {
+                if notes[i] == notes[i + 1] {
+                    return Err(DuplicateNoteError(format!(
+                        "Guitar frequency list has duplicates: {:?} and {:?}",
+                        notes[i],
+                        notes[i + 1]
+                    )));
+                }
             }
         }
         Ok(NoteRegistry { notes })
@@ -139,21 +132,21 @@ impl NoteRegistry {
         &self.notes
     }
 
+    fn find_note(&self, note: &Note) -> Option<usize> {
+        self.notes.iter().position(|p| p == note)
+    }
+
     pub fn get(&self, note_name: NoteName, octave: usize) -> Option<&Note> {
         let query_note = Note {
             name: note_name,
             octave,
             frequency: 0.0,
         };
-        if let Ok(idx) = self.notes.binary_search(&query_note) {
-            Some(&self.notes[idx])
-        } else {
-            None
-        }
+        self.find_note(&query_note).map(|idx| &self.notes[idx])
     }
 
     pub fn iter_from<'a>(&'a self, starting_note: &'a Note) -> impl Iterator<Item = &'a Note> {
-        if let Ok(idx) = self.notes.binary_search(starting_note) {
+        if let Some(idx) = self.find_note(starting_note) {
             self.notes.iter().skip(idx)
         } else {
             self.notes.iter().skip(self.notes.len())
@@ -203,7 +196,7 @@ impl Tuning {
     }
 
     pub fn note(&self, string_idx: usize) -> &Note {
-        assert!(
+        debug_assert!(
             string_idx > 0 && string_idx <= self.values.len(),
             "Guitar string index {} is out of bounds ({}, {})",
             string_idx,
@@ -220,8 +213,7 @@ impl Tuning {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_csv_impl;
-    use super::TuningSpecification;
+    use super::*;
     use crate::note::{Note, NoteName};
     use csv::Reader;
 
@@ -294,5 +286,136 @@ mod tests {
         let rdr = Reader::from_reader(data.as_bytes());
         let actual = parse_csv_impl(rdr).unwrap();
         assert!(expected.into_iter().eq(actual.into_iter()));
+    }
+
+    #[test]
+    fn test_note_registry_notes_empty() {
+        let reg = NoteRegistry::from_notes(vec![]).unwrap();
+        assert_eq!(0, reg.notes().len());
+    }
+
+    #[test]
+    fn test_note_registry_get_empty() {
+        let reg = NoteRegistry::from_notes(vec![]).unwrap();
+        assert_eq!(None, reg.get(NoteName::A, 2));
+        assert_eq!(None, reg.get(NoteName::E, 3));
+        assert_eq!(None, reg.get(NoteName::F, 4));
+        assert_eq!(None, reg.get(NoteName::GSharp, 1));
+    }
+
+    #[test]
+    fn test_note_registry_iter_from_empty() {
+        let note = Note {
+            octave: 5,
+            name: NoteName::E,
+            frequency: 64.4,
+        };
+        let reg = NoteRegistry::from_notes(vec![]).unwrap();
+        assert_eq!(None, reg.iter_from(&note).next());
+    }
+
+    #[test]
+    fn test_note_registry_notes() {
+        let reg = NoteRegistry::from_notes(vec![
+            Note {
+                octave: 5,
+                name: NoteName::E,
+                frequency: 300.0,
+            },
+            Note {
+                octave: 3,
+                name: NoteName::F,
+                frequency: 62.2,
+            },
+            Note {
+                octave: 4,
+                name: NoteName::C,
+                frequency: 75.5,
+            },
+        ])
+        .unwrap();
+        let expected = vec![
+            Note {
+                octave: 3,
+                name: NoteName::F,
+                frequency: 62.2,
+            },
+            Note {
+                octave: 4,
+                name: NoteName::C,
+                frequency: 75.5,
+            },
+            Note {
+                octave: 5,
+                name: NoteName::E,
+                frequency: 300.0,
+            },
+        ];
+        assert_eq!(&expected, reg.notes());
+    }
+
+    #[test]
+    fn test_note_registry_get() {
+        let notes = vec![
+            Note {
+                octave: 3,
+                name: NoteName::E,
+                frequency: 300.0,
+            },
+            Note {
+                octave: 3,
+                name: NoteName::F,
+                frequency: 62.2,
+            },
+            Note {
+                octave: 3,
+                name: NoteName::C,
+                frequency: 75.5,
+            },
+        ];
+        let reg = NoteRegistry::from_notes(notes.clone()).unwrap();
+        assert_eq!(Some(&notes[0]), reg.get(NoteName::E, 3));
+        assert_eq!(Some(&notes[1]), reg.get(NoteName::F, 3));
+        assert_eq!(Some(&notes[2]), reg.get(NoteName::C, 3));
+        assert_eq!(None, reg.get(NoteName::D, 2));
+    }
+
+    fn iter_len<T>(iter: impl Iterator<Item = T>) -> usize {
+        let mut count = 0;
+        for _ in iter {
+            count += 1;
+        }
+        count
+    }
+
+    #[test]
+    fn test_note_registry_iter_from() {
+        let notes = vec![
+            Note {
+                octave: 3,
+                name: NoteName::E,
+                frequency: 300.0,
+            },
+            Note {
+                octave: 3,
+                name: NoteName::F,
+                frequency: 62.2,
+            },
+            Note {
+                octave: 3,
+                name: NoteName::C,
+                frequency: 75.5,
+            },
+        ];
+        let nonexistent_note = Note {
+            octave: 4,
+            name: NoteName::D,
+            frequency: 85.5,
+        };
+        let reg = NoteRegistry::from_notes(notes.clone()).unwrap();
+        assert_eq!(1, iter_len(reg.iter_from(&notes[0])));
+        assert_eq!(3, iter_len(reg.iter_from(&notes[1])));
+        assert_eq!(2, iter_len(reg.iter_from(&notes[2])));
+        assert_eq!(0, iter_len(reg.iter_from(&nonexistent_note)));
     }
 }


### PR DESCRIPTION
Fixes #25 .

Bug was related to incorrect sorting of `Note` objects inside `NoteRegistry`. The previous ordering defined by first comparing octave and then the note name does not result in total frequency ordering. This MR fixes this issue and adds bugfix confirmation tests that fails without the bugfix.