### PR TITLE
Create separate linux and windows builds

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,6 +26,7 @@ jobs:
         - ubuntu-pinned
         - ubuntu-stable
         - cross-linux-gnu
+        - windows-msvc
         include:
         - build: ubuntu-pinned
           os: ubuntu-18.04
@@ -37,12 +38,15 @@ jobs:
           os: ubuntu-18.04
           rust: stable
           target: x86_64-unknown-linux-gnu
+        - build: windows-msvc
+          os: windows-latest
+          rust: stable
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
 
     - name: Install packages (Ubuntu)
-      if: matrix.target == ''
+      if: matrix.os == 'ubuntu-18.04' && matrix.target == ''
       run: |
         sudo apt-get update && sudo apt-get install -y `cat ci/ubuntu-packages`
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ edition = "2018"
 thiserror = "1.0"
 rustfft = "6.0"
 realfft = "2.0"
-cpal = { version = "0.13.3", features = ["jack"] }
 csv = "1.1"
 rand = "0.8"
 serde = { version = "1", features = ["derive"]}
@@ -20,6 +19,12 @@ console = "0.14"
 minifb = { version = "0.13", optional = true }
 plotters = { version = "0.3", default_features = false, features = ["ttf", "line_series"], optional = true}
 plotters-bitmap = { version = "0.3", default_features = false, optional = true }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+cpal = { version = "0.13.3", default_features = false}
+
+[target.'cfg(target_os = "linux")'.dependencies]
+cpal = { version = "0.13.3", default_features = false, features = ["jack"] }
 
 [features]
 default = []


### PR DESCRIPTION
Create separate linux and windows builds. ASIO support on Windows is currently disabled due to build conflicts discussed at https://github.com/RustAudio/cpal/issues/383 . Once that issue is resolved, we need to enable ASIO for faster audio IO on windows.